### PR TITLE
feat(core-vue): expose a prompt component as an LLM tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,66 @@ const markdown = await renderComponent(Prompt, { name: 'Velin' })
 
 `componentFromSource` and `componentFromFile` evaluate transformed ESM and are not a sandbox or security boundary. Use them only with trusted source.
 
+### As an LLM tool (Vue)
+
+A prompt component is already most of a tool: its props are the arguments, its script does the work, and what it renders is the answer. `defineTool` closes the gap by deriving the argument schema from the props, so the same component can be handed to a model.
+
+```html
+<!-- GetWeather.vue -->
+<script setup lang="ts">
+import { onServerPrefetch, ref } from 'vue'
+
+const props = defineProps<{ city: string }>()
+
+const forecast = ref('')
+onServerPrefetch(async () => {
+  forecast.value = await fetch(`https://example.com/weather/${props.city}`).then(r => r.text())
+})
+</script>
+
+<template>
+  <div>The weather in {{ city }} is {{ forecast }}.</div>
+</template>
+```
+
+```ts
+import { defineTool } from '@velin-dev/core-vue'
+
+import GetWeather from './GetWeather.vue'
+
+const tool = defineTool(GetWeather, { description: 'Get the current weather for a city.' })
+
+tool.function.parameters
+// { type: 'object', properties: { city: { type: 'string' } }, required: ['city'], additionalProperties: false }
+```
+
+Rendering goes through Vue's server renderer, so `onServerPrefetch` and async `setup` are awaited before the result comes back.
+
+Runners that execute tools themselves take the tool as-is:
+
+```ts
+import { generateText } from '@xsai/generate-text'
+
+await generateText({ ...options, messages, tools: [tool] })
+```
+
+With an SDK that only sends the definition, the tool serializes to the wire object — `execute` is a function, so it drops out — and closes the loop in one call:
+
+```ts
+const completion = await openai.chat.completions.create({ model, messages, tools: [tool] })
+const call = completion.choices[0].message.tool_calls?.[0]
+
+if (call) {
+  // `arguments` arrives as a JSON string; `execute` accepts it directly.
+  const content = await tool.execute(call.function.arguments, { toolCallId: call.id })
+  messages.push({ role: 'tool', tool_call_id: call.id, content })
+}
+```
+
+In a component, `useTool` from `@velin-dev/vue` returns the same tool plus a `pending` ref for the in-flight state.
+
+Arguments the component does not declare are dropped, and missing or mistyped ones raise a `VelinToolInputError` whose message is written to be handed back to the model.
+
 ## Similar projects
 
 - [poml](https://github.com/microsoft/poml) / [pomljs](https://github.com/microsoft/poml)

--- a/packages/core-vue/src/index.ts
+++ b/packages/core-vue/src/index.ts
@@ -40,11 +40,24 @@ export async function renderSFCString<RawProps = any>(
   return renderSFCStringBrowser(source, data, typeof options === 'string' ? options : options?.basePath)
 }
 
+export type {
+  ComponentProp,
+  DefineToolOptions,
+  JsonSchema,
+  VelinTool,
+  VelinToolExecuteOptions,
+} from './render-shared'
+
 export {
+  defineTool,
   normalizeProps,
   onlyRender,
   onlySetup,
+  propsToJsonSchema,
   renderComponent,
   resolveProps,
+  useToolContext,
+  velinToolContextKey,
+  VelinToolInputError,
 } from './render-shared'
 export * from './types'

--- a/packages/core-vue/src/render-browser/index.ts
+++ b/packages/core-vue/src/render-browser/index.ts
@@ -6,7 +6,7 @@ import { fromHtml } from 'hast-util-from-html'
 import { renderMarkdownString } from './markdown'
 import { renderSFCString } from './sfc'
 
-export { renderComponent, resolveProps } from '../render-shared'
+export { defineTool, propsToJsonSchema, renderComponent, resolveProps, useToolContext, velinToolContextKey, VelinToolInputError } from '../render-shared'
 export { renderMarkdownString } from './markdown'
 export { renderSFCString } from './sfc'
 

--- a/packages/core-vue/src/render-node/index.ts
+++ b/packages/core-vue/src/render-node/index.ts
@@ -6,7 +6,7 @@ import { fromHtml } from 'hast-util-from-html'
 import { renderMarkdownString } from './markdown'
 import { renderSFCString } from './sfc'
 
-export { renderComponent, resolveProps } from '../render-shared'
+export { defineTool, propsToJsonSchema, renderComponent, resolveProps, useToolContext, velinToolContextKey, VelinToolInputError } from '../render-shared'
 export { renderMarkdownString } from './markdown'
 export { renderSFCString } from './sfc'
 

--- a/packages/core-vue/src/render-shared/index.ts
+++ b/packages/core-vue/src/render-shared/index.ts
@@ -1,4 +1,6 @@
 export * from './compile'
 export * from './component'
+export * from './json-schema'
 export * from './props'
 export * from './template'
+export * from './tool'

--- a/packages/core-vue/src/render-shared/json-schema.test.ts
+++ b/packages/core-vue/src/render-shared/json-schema.test.ts
@@ -1,0 +1,96 @@
+import type { ComponentProp } from './props'
+
+import { describe, expect, it } from 'vitest'
+
+import { propsToJsonSchema } from './json-schema'
+
+function prop(partial: Partial<ComponentProp> & { key: string }): ComponentProp {
+  return { title: partial.key, type: 'string', required: false, ...partial } as ComponentProp
+}
+
+describe('propsToJsonSchema', () => {
+  describe('scalar types', () => {
+    it('should map a string prop to a string schema', () => {
+      const schema = propsToJsonSchema([prop({ key: 'city', type: 'string' })])
+      expect(schema.properties).toEqual({ city: { type: 'string' } })
+    })
+
+    it('should map a number prop to a number schema', () => {
+      const schema = propsToJsonSchema([prop({ key: 'days', type: 'number' })])
+      expect(schema.properties).toEqual({ days: { type: 'number' } })
+    })
+
+    it('should map a boolean prop to a boolean schema', () => {
+      const schema = propsToJsonSchema([prop({ key: 'metric', type: 'boolean' })])
+      expect(schema.properties).toEqual({ metric: { type: 'boolean' } })
+    })
+  })
+
+  describe('array type', () => {
+    it('should map an array prop to an array schema with an unconstrained items', () => {
+      const schema = propsToJsonSchema([prop({ key: 'tags', type: 'array' })])
+      expect(schema.properties).toEqual({ tags: { type: 'array', items: {} } })
+    })
+  })
+
+  describe('unknown type', () => {
+    it('should map an unknown prop to an empty schema that accepts any value', () => {
+      const schema = propsToJsonSchema([prop({ key: 'payload', type: 'unknown' })])
+      expect(schema.properties).toEqual({ payload: {} })
+    })
+  })
+
+  describe('required', () => {
+    it('should collect required keys in declaration order', () => {
+      const schema = propsToJsonSchema([
+        prop({ key: 'city', required: true }),
+        prop({ key: 'unit' }),
+        prop({ key: 'days', type: 'number', required: true }),
+      ])
+      expect(schema.required).toEqual(['city', 'days'])
+    })
+
+    // An empty `required` is invalid under JSON Schema draft-04, and some
+    // providers still validate against it.
+    it('should omit required entirely when no prop is required', () => {
+      const schema = propsToJsonSchema([prop({ key: 'city' })])
+      expect('required' in schema).toBe(false)
+    })
+  })
+
+  describe('description', () => {
+    it('should carry a prop description into the property schema', () => {
+      const schema = propsToJsonSchema([prop({ key: 'city', description: 'City to look up, e.g. Tokyo' })])
+      expect(schema.properties).toEqual({ city: { type: 'string', description: 'City to look up, e.g. Tokyo' } })
+    })
+
+    it('should omit description when the prop has none', () => {
+      const schema = propsToJsonSchema([prop({ key: 'city' })])
+      expect(schema.properties.city).toEqual({ type: 'string' })
+    })
+  })
+
+  describe('envelope', () => {
+    // Providers reject a tool whose parameters are not an object schema, so
+    // this shape has to hold even when there is nothing to describe.
+    it('should emit an empty object schema for a component with no props', () => {
+      expect(propsToJsonSchema([])).toEqual({
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      })
+    })
+
+    it('should always disallow additional properties', () => {
+      const schema = propsToJsonSchema([prop({ key: 'city' })])
+      expect(schema.additionalProperties).toBe(false)
+    })
+
+    // `resolveProps` sets title === key, so emitting it would only repeat the
+    // property name back to the model.
+    it('should not emit title', () => {
+      const schema = propsToJsonSchema([prop({ key: 'city' })])
+      expect('title' in schema.properties.city).toBe(false)
+    })
+  })
+})

--- a/packages/core-vue/src/render-shared/json-schema.ts
+++ b/packages/core-vue/src/render-shared/json-schema.ts
@@ -1,0 +1,86 @@
+import type { ComponentProp } from './props'
+
+/**
+ * JSON Schema describing the arguments of a prompt component used as an LLM
+ * tool.
+ *
+ * NOTICE:
+ * Declared as a type alias rather than an interface on purpose. TypeScript
+ * grants an implicit index signature to object type aliases but not to
+ * interfaces, and without one this is not assignable to the
+ * `Record<string, unknown>` that tool-calling SDKs declare for the parameters
+ * field (for example `Tool['function']['parameters']` in `@xsai/shared-chat`).
+ * Switching this to an interface compiles here and breaks at every call site.
+ */
+// eslint-disable-next-line ts/consistent-type-definitions
+export type JsonSchema = {
+  type: 'object'
+  properties: Record<string, Record<string, unknown>>
+  required?: string[]
+  additionalProperties: false
+}
+
+function schemaForProp(prop: ComponentProp): Record<string, unknown> {
+  switch (prop.type) {
+    case 'string':
+      return { type: 'string' }
+    case 'number':
+      // Vue's `Number` is a double; a component that wants an integer says so
+      // through its own description rather than having it guessed here.
+      return { type: 'number' }
+    case 'boolean':
+      return { type: 'boolean' }
+    case 'array':
+      // The element type is not recoverable from a runtime `Array` constructor,
+      // and `items` is required for an array schema to be well-formed.
+      return { type: 'array', items: {} }
+    case 'unknown':
+    default:
+      // `Object`, `Date`, custom classes and union constructors all arrive as
+      // `unknown`. An empty schema accepts any value, which is exactly what the
+      // component itself does with such a prop.
+      return {}
+  }
+}
+
+/**
+ * Derives the tool argument schema from a prompt component's resolved props.
+ *
+ * Before:
+ * - `[{ key: 'city', title: 'city', type: 'string', required: true }]`
+ *
+ * After:
+ * - `{ type: 'object', properties: { city: { type: 'string' } }, required: ['city'], additionalProperties: false }`
+ */
+export function propsToJsonSchema(props: ComponentProp[]): JsonSchema {
+  const properties: Record<string, Record<string, unknown>> = {}
+  const required: string[] = []
+
+  for (const prop of props) {
+    const propSchema = schemaForProp(prop)
+    if (prop.description)
+      propSchema.description = prop.description
+
+    // `title` is deliberately not emitted: `resolveProps` always sets it equal
+    // to the key, so it would only repeat the property name back to the model.
+    properties[prop.key] = propSchema
+
+    if (prop.required)
+      required.push(prop.key)
+  }
+
+  const schema: JsonSchema = {
+    type: 'object',
+    properties,
+    // Undeclared arguments are dropped before rendering, so advertising that
+    // up front stops the model from inventing them in the first place.
+    additionalProperties: false,
+  }
+
+  // Omitted rather than sent as `[]`: JSON Schema draft-04 requires `required`
+  // to hold at least one entry, and some provider-side validators enforce it.
+  if (required.length > 0)
+    schema.required = required
+
+  return schema
+}

--- a/packages/core-vue/src/render-shared/props.test.ts
+++ b/packages/core-vue/src/render-shared/props.test.ts
@@ -189,6 +189,47 @@ describe('resolveProps', () => {
     })
   })
 
+  describe('array declarations', () => {
+    // `defineProps(['city'])` survives compilation as `props: ['city']`.
+    // Enumerating it as an object would name the props after array indices.
+    it('should resolve array-declared props by name', () => {
+      const component = {
+        _component: {
+          props: ['city', 'unit'],
+        },
+      }
+      const props = resolveProps(component as any)
+      expect(props).toEqual([
+        { key: 'city', title: 'city', type: 'unknown', required: false },
+        { key: 'unit', title: 'unit', type: 'unknown', required: false },
+      ])
+    })
+
+    it('should resolve array-declared props from ComponentInternalInstance', () => {
+      const component = { props: ['city'] }
+      const props = resolveProps(component as any)
+      expect(props).toEqual([
+        { key: 'city', title: 'city', type: 'unknown', required: false },
+      ])
+    })
+  })
+
+  describe('description', () => {
+    it('should read a description off the prop options', () => {
+      const component = {
+        _component: {
+          props: {
+            city: { type: String, required: true, description: 'City to look up' },
+          },
+        },
+      }
+      const props = resolveProps(component as any)
+      expect(props).toEqual([
+        { key: 'city', title: 'city', type: 'string', required: true, description: 'City to look up' },
+      ])
+    })
+  })
+
   describe('empty props', () => {
     it('should return empty array when no props defined', () => {
       const component = {}

--- a/packages/core-vue/src/render-shared/props.ts
+++ b/packages/core-vue/src/render-shared/props.ts
@@ -36,6 +36,12 @@ export type ComponentProp = (ComponentPropText | ComponentPropBool | ComponentPr
   title: string
   key: string
   required?: boolean
+  /**
+   * Read from an extra `description` key on the runtime prop options, which Vue
+   * itself ignores. Carried through to the tool argument schema so a model can
+   * be told what a parameter means.
+   */
+  description?: string
 }
 
 function willTurnIntoNumber(value: unknown): boolean {
@@ -130,6 +136,37 @@ function inferType(
   return type
 }
 
+function resolvePropDef(key: string, propDef: unknown): ComponentProp {
+  const options = propDef != null && typeof propDef === 'object'
+    ? propDef as { required?: boolean, description?: string }
+    : undefined
+
+  const prop: ComponentProp = {
+    key,
+    title: key,
+    type: inferType(propDef),
+    required: options && 'required' in options ? options.required : false,
+  }
+
+  if (options && typeof options.description === 'string')
+    prop.description = options.description
+
+  return prop
+}
+
+function resolvePropsOption(props: object): ComponentProp[] {
+  // `defineProps(['city'])` declares names without types. Enumerating it as an
+  // object would yield array indices as prop names, which then travel onwards
+  // as the component's declared prop list.
+  if (Array.isArray(props)) {
+    return props
+      .filter((key): key is string => typeof key === 'string')
+      .map(key => ({ key, title: key, type: 'unknown', required: false }))
+  }
+
+  return Object.entries(props).map(([key, propDef]) => resolvePropDef(key, propDef))
+}
+
 /**
  * @see https://github.com/vuejs/devtools/blob/e7dffa24fe98b212404a1451818b6c66739f88ee/packages/devtools-kit/src/core/component/state/process.ts#L62
  * @see https://github.com/vuejs/devtools/blob/e7dffa24fe98b212404a1451818b6c66739f88ee/packages/devtools-kit/src/core/app/index.ts#L14
@@ -138,24 +175,10 @@ function inferType(
  */
 export function resolveProps(component: RenderComponentInputComponent<any> | App<any>): ComponentProp[] {
   if (component._component && component._component.props && typeof component._component.props === 'object') {
-    return Object.entries(component._component.props).map(([key, propDef]) => {
-      return {
-        key,
-        title: key,
-        type: inferType(propDef),
-        required: propDef != null && typeof propDef === 'object' && 'required' in propDef ? (propDef as { required?: boolean }).required : false,
-      }
-    })
+    return resolvePropsOption(component._component.props)
   }
   else if ((component as unknown as ComponentInternalInstance).props && typeof (component as unknown as ComponentInternalInstance).props === 'object') {
-    return Object.entries((component as unknown as ComponentInternalInstance).props).map(([key, propDef]) => {
-      return {
-        key,
-        title: key,
-        type: inferType(propDef),
-        required: propDef != null && typeof propDef === 'object' && 'required' in propDef ? (propDef as { required?: boolean }).required : false,
-      }
-    })
+    return resolvePropsOption((component as unknown as ComponentInternalInstance).props)
   }
   else {
     return []

--- a/packages/core-vue/src/render-shared/tool.test.ts
+++ b/packages/core-vue/src/render-shared/tool.test.ts
@@ -1,0 +1,315 @@
+import type { VelinTool } from './tool'
+
+import { describe, expect, it } from 'vitest'
+import { defineComponent, h, onServerPrefetch, ref } from 'vue'
+
+import { defineTool, useToolContext, VelinToolInputError } from './tool'
+
+/**
+ * The tool contract of a runner that executes tools itself, transcribed from
+ * `Tool` in `@xsai/shared-chat@0.5.0-beta.2`. It is repeated here rather than
+ * imported so that this package stays free of SDK dependencies.
+ *
+ * NOTICE:
+ * This exists to pin parameter variance. Function parameters are contravariant,
+ * so declaring `execute`'s first parameter as anything narrower than `unknown`
+ * — or requiring fields on its second — silently makes {@link VelinTool}
+ * unassignable here, and the failure surfaces in the user's project rather than
+ * in this one. `pnpm typecheck` covers this file, so the check is enforced.
+ */
+interface SdkTool {
+  execute: (input: unknown, options: { abortSignal?: AbortSignal, messages: unknown[], toolCallId: string }) => Promise<object | string | unknown[]> | object | string | unknown[]
+  function: { description?: string, name: string, parameters: Record<string, unknown>, strict?: boolean }
+  type: 'function'
+}
+
+type AssertExtends<Expected, Actual extends Expected> = Actual
+
+/** Fails `pnpm typecheck` if {@link VelinTool} stops satisfying {@link SdkTool}. */
+export type ToolSatisfiesSdkContract = AssertExtends<SdkTool, VelinTool>
+
+const GetWeather = defineComponent({
+  name: 'get_weather',
+  props: {
+    city: { type: String, required: true, description: 'City to look up' },
+    days: { type: Number },
+  },
+  setup: props => () => h('div', `Weather for ${props.city} over ${props.days ?? 1} day(s)`),
+})
+
+const NoProps = defineComponent({
+  name: 'list_cities',
+  setup: () => () => h('div', 'Tokyo, Osaka'),
+})
+
+describe('defineTool', () => {
+  describe('descriptor', () => {
+    it('should derive the argument schema from the component props', () => {
+      const tool = defineTool(GetWeather)
+
+      expect(tool.type).toBe('function')
+      expect(tool.function.name).toBe('get_weather')
+      expect(tool.function.parameters).toEqual({
+        type: 'object',
+        properties: {
+          city: { type: 'string', description: 'City to look up' },
+          days: { type: 'number' },
+        },
+        required: ['city'],
+        additionalProperties: false,
+      })
+    })
+
+    it('should let options override the component name and set a description', () => {
+      const tool = defineTool(GetWeather, { name: 'weather', description: 'Get the weather.' })
+
+      expect(tool.function.name).toBe('weather')
+      expect(tool.function.description).toBe('Get the weather.')
+    })
+
+    it('should omit description when none is given', () => {
+      expect('description' in defineTool(GetWeather).function).toBe(false)
+    })
+
+    it('should throw when no name can be derived', () => {
+      const anonymous = defineComponent({ setup: () => () => h('div', 'hi') })
+      expect(() => defineTool(anonymous)).toThrow(/Unable to derive a tool name/)
+    })
+
+    // Vue's own `getComponentName` reads `name` first and treats `__name` as
+    // the inferred fallback, so `defineOptions({ name })` has to win.
+    it('should prefer a declared name over the one inferred from the file', () => {
+      const declared = Object.assign(
+        defineComponent({
+          name: 'get_weather',
+          props: { city: { type: String, required: true } },
+          setup: props => () => h('div', props.city),
+        }),
+        { __name: 'GetWeather' },
+      )
+
+      expect(defineTool(declared).function.name).toBe('get_weather')
+    })
+
+    // This repo names prompt components `*.velin.vue`, and the compiler infers
+    // `Prompt.velin` from that — a dot, which providers reject.
+    it('should throw when the derived name is not a usable tool name', () => {
+      const dotted = Object.assign(
+        defineComponent({ setup: () => () => h('div', 'hi') }),
+        { __name: 'Prompt.velin' },
+      )
+
+      expect(() => defineTool(dotted)).toThrow(/cannot be used as a tool name/)
+    })
+
+    it('should accept array-declared props as named arguments', () => {
+      const arrayProps = defineComponent({
+        name: 'array_props',
+        props: ['city'],
+        setup: props => () => h('div', `Weather for ${props.city}`),
+      })
+
+      expect(defineTool(arrayProps).function.parameters).toEqual({
+        type: 'object',
+        properties: { city: {} },
+        additionalProperties: false,
+      })
+    })
+
+    // Shape emitted by the SFC compiler for
+    // `defineProps<{ city: string, days?: number, when?: Date }>()`, which is
+    // how a tool written as a `.vue` file arrives here.
+    it('should read the name and props a single-file component compiles to', () => {
+      const compiled = Object.assign(
+        defineComponent({
+          props: {
+            city: { type: String, required: true },
+            days: { type: Number, required: false },
+            when: { type: Date, required: false },
+          },
+          setup: () => () => h('div', 'forecast'),
+        }),
+        // The compiler also emits `__name`, which `defineComponent`'s own types
+        // do not model.
+        { __name: 'get_forecast' },
+      )
+
+      const tool = defineTool(compiled)
+
+      expect(tool.function.name).toBe('get_forecast')
+      expect(tool.function.parameters).toEqual({
+        type: 'object',
+        properties: {
+          city: { type: 'string' },
+          days: { type: 'number' },
+          // `Date` carries no JSON Schema equivalent, so it stays unconstrained.
+          when: {},
+        },
+        required: ['city'],
+        additionalProperties: false,
+      })
+    })
+
+    // The enumerable fields are the OpenAI wire tool; `execute` is a function
+    // and drops out of serialization on its own.
+    it('should serialize to a wire tool object', () => {
+      const tool = defineTool(NoProps, { description: 'List cities.' })
+
+      expect(JSON.parse(JSON.stringify(tool))).toEqual({
+        type: 'function',
+        function: {
+          name: 'list_cities',
+          description: 'List cities.',
+          parameters: { type: 'object', properties: {}, additionalProperties: false },
+        },
+      })
+    })
+  })
+
+  describe('execute', () => {
+    it('should render the component with the given arguments', async () => {
+      const tool = defineTool(GetWeather)
+      await expect(tool.execute({ city: 'Tokyo', days: 3 })).resolves.toBe('Weather for Tokyo over 3 day(s)\n')
+    })
+
+    // Every OpenAI-shaped API hands back `function.arguments` as a JSON string.
+    it('should accept arguments as a JSON string', async () => {
+      const tool = defineTool(GetWeather)
+      await expect(tool.execute('{"city":"Osaka"}')).resolves.toBe('Weather for Osaka over 1 day(s)\n')
+    })
+
+    it('should treat empty input as no arguments', async () => {
+      const tool = defineTool(NoProps)
+
+      await expect(tool.execute()).resolves.toBe('Tokyo, Osaka\n')
+      await expect(tool.execute('')).resolves.toBe('Tokyo, Osaka\n')
+      await expect(tool.execute(null)).resolves.toBe('Tokyo, Osaka\n')
+    })
+
+    it('should await onServerPrefetch before returning', async () => {
+      const Prefetching = defineComponent({
+        name: 'forecast',
+        props: { city: { type: String, required: true } },
+        setup(props) {
+          const forecast = ref('unresolved')
+          onServerPrefetch(async () => {
+            await new Promise(resolve => setTimeout(resolve, 5))
+            forecast.value = `sunny in ${props.city}`
+          })
+          return () => h('div', `It is ${forecast.value}`)
+        },
+      })
+
+      await expect(defineTool(Prefetching).execute({ city: 'Kyoto' })).resolves.toBe('It is sunny in Kyoto\n')
+    })
+
+    it('should expose the call context to the component', async () => {
+      const controller = new AbortController()
+      const Contextual = defineComponent({
+        name: 'contextual',
+        setup() {
+          const { toolCallId } = useToolContext()
+          return () => h('div', `call ${toolCallId}`)
+        },
+      })
+
+      const rendered = await defineTool(Contextual).execute(undefined, {
+        toolCallId: 'call-1',
+        abortSignal: controller.signal,
+      })
+      expect(rendered).toBe('call call-1\n')
+    })
+
+    it('should reject when the call was already aborted', async () => {
+      const controller = new AbortController()
+      controller.abort()
+
+      await expect(defineTool(NoProps).execute(undefined, { abortSignal: controller.signal })).rejects.toThrow()
+    })
+  })
+
+  describe('argument validation', () => {
+    it('should throw when a required argument is missing', async () => {
+      await expect(defineTool(GetWeather).execute({ days: 2 })).rejects.toThrow(VelinToolInputError)
+    })
+
+    it('should report every problem in one error', async () => {
+      const error = await defineTool(GetWeather).execute({ days: 'three' }).catch((e: unknown) => e)
+
+      expect(error).toBeInstanceOf(VelinToolInputError)
+      expect((error as VelinToolInputError).issues).toEqual([
+        'missing required argument "city"',
+        'argument "days" should be number, received string',
+      ])
+    })
+
+    it('should throw when the arguments are not valid JSON', async () => {
+      await expect(defineTool(GetWeather).execute('{"city":')).rejects.toThrow(/not valid JSON/)
+    })
+
+    it('should throw when the arguments are not an object', async () => {
+      await expect(defineTool(GetWeather).execute('["Tokyo"]')).rejects.toThrow(/must be a JSON object/)
+    })
+
+    it('should render array-declared props from the model arguments', async () => {
+      const arrayProps = defineComponent({
+        name: 'array_props',
+        props: ['city'],
+        setup: props => () => h('div', `Weather for ${props.city}`),
+      })
+
+      await expect(defineTool(arrayProps).execute({ city: 'Tokyo' })).resolves.toBe('Weather for Tokyo\n')
+    })
+
+    // Arguments are read as own properties only. Otherwise a prop named after
+    // an `Object.prototype` member picks up the inherited function, and the
+    // model is told its `toString` argument "should be string, received
+    // function" — a complaint no argument it sends can resolve.
+    //
+    // Only the reported issue is velin's to fix: Vue itself cannot deliver a
+    // prop named `toString` to `props.toString`, so such a prop is unusable
+    // regardless of what is passed.
+    it('should not mistake prototype members for supplied arguments', async () => {
+      const shadowing = defineComponent({
+        name: 'shadowing',
+        props: { toString: { type: String, required: true } },
+        setup: () => () => h('div', 'rendered'),
+      })
+
+      const error = await defineTool(shadowing).execute({}).catch((e: unknown) => e)
+      expect((error as VelinToolInputError).issues).toEqual(['missing required argument "toString"'])
+    })
+
+    it('should treat JSON null as no arguments', async () => {
+      await expect(defineTool(NoProps).execute('null')).resolves.toBe('Tokyo, Osaka\n')
+    })
+
+    it('should let an omitted optional argument fall back to the prop default', async () => {
+      const WithDefault = defineComponent({
+        name: 'with_default',
+        props: { unit: { type: String, default: 'celsius' } },
+        setup: props => () => h('div', `unit ${props.unit}`),
+      })
+
+      await expect(defineTool(WithDefault).execute({})).resolves.toBe('unit celsius\n')
+    })
+
+    // A model that invents an undeclared argument would otherwise have it fall
+    // through as an attribute on the root element, which `toMarkdown` then
+    // renders into the very result being fed back to the model.
+    it('should drop undeclared arguments instead of rendering them', async () => {
+      const Anchor = defineComponent({
+        name: 'anchor_tool',
+        props: { city: { type: String, required: true } },
+        setup: props => () => h('a', `Weather for ${props.city}`),
+      })
+
+      const tool = defineTool(Anchor)
+      const injected = await tool.execute({ city: 'Tokyo', href: 'https://attacker.example/steal' })
+
+      expect(injected).not.toContain('attacker.example')
+      // Identical to the result the same call produces without the extra key.
+      expect(injected).toBe(await tool.execute({ city: 'Tokyo' }))
+    })
+  })
+})

--- a/packages/core-vue/src/render-shared/tool.ts
+++ b/packages/core-vue/src/render-shared/tool.ts
@@ -1,0 +1,283 @@
+import type { ComponentPropsOptions, InjectionKey } from 'vue'
+
+import type {
+  RenderComponentInputComponent,
+  ResolveRenderComponentInputProps,
+} from '../types'
+import type { ComponentProp } from './props'
+
+import { toMarkdown } from '@velin-dev/utils/to-md'
+import { renderToString } from '@vue/server-renderer'
+import { inject } from 'vue'
+
+import { onlyRender } from './component'
+import { propsToJsonSchema } from './json-schema'
+import { resolveProps } from './props'
+
+/**
+ * Call-time context handed to a tool component while it renders.
+ *
+ * NOTICE:
+ * Every field is optional on purpose. Tool-calling SDKs declare their own,
+ * stricter execute options (`@xsai/shared-chat`'s `ToolExecuteOptions` requires
+ * `messages` and `toolCallId`), and function parameters are contravariant — a
+ * narrower parameter type here would make {@link VelinTool} unassignable to
+ * those SDKs' tool types. Do not tighten these.
+ */
+export interface VelinToolExecuteOptions {
+  abortSignal?: AbortSignal
+  messages?: unknown[]
+  toolCallId?: string
+}
+
+export const velinToolContextKey: InjectionKey<VelinToolExecuteOptions> = Symbol('velin-tool-context')
+
+/**
+ * Reads the context of the tool call currently rendering the component, so a
+ * component can pass `abortSignal` to whatever it fetches inside
+ * `onServerPrefetch`. Returns an empty object when the component is rendered
+ * outside of a tool call.
+ */
+export function useToolContext(): VelinToolExecuteOptions {
+  return inject(velinToolContextKey, {})
+}
+
+/**
+ * A prompt component exposed as an LLM tool.
+ *
+ * The enumerable fields are exactly the OpenAI Chat Completions tool object, so
+ * `JSON.stringify(tool)` is a valid wire payload — `execute` is a function and
+ * is dropped by serialization. Runners that execute tools themselves (xsai,
+ * among others) call `execute` directly.
+ */
+export interface VelinTool {
+  type: 'function'
+  function: {
+    name: string
+    description?: string
+    parameters: Record<string, unknown>
+  }
+  execute: (input?: unknown, options?: VelinToolExecuteOptions) => Promise<string>
+}
+
+export interface DefineToolOptions {
+  /**
+   * Name the model calls. Defaults to the component's own name, which Vue's SFC
+   * compiler derives from the file name.
+   */
+  name?: string
+  /** What the tool does. Written for the model, not for the reader of the code. */
+  description?: string
+}
+
+/** Thrown when a tool call's arguments cannot be used to render the component. */
+export class VelinToolInputError extends Error {
+  readonly toolName: string
+  /** Every problem found, so one error can correct the model in a single turn. */
+  readonly issues: string[]
+
+  constructor(toolName: string, issues: string[]) {
+    super(`Tool "${toolName}" received invalid arguments: ${issues.join('; ')}`)
+    this.name = 'VelinToolInputError'
+    this.toolName = toolName
+    this.issues = issues
+  }
+}
+
+/**
+ * Providers accept tool names matching this and reject the rest, so a name that
+ * cannot be called is caught while defining the tool rather than on the first
+ * request.
+ */
+const TOOL_NAME_PATTERN = /^[\w-]{1,64}$/
+
+function resolveToolName(component: RenderComponentInputComponent<any>, name?: string): string {
+  // Declared name first, inferred name second — the order Vue's own
+  // `getComponentName` uses, so `defineOptions({ name })` wins over the name
+  // the SFC compiler derives from the file.
+  const resolved = name
+    ?? (component as { name?: string }).name
+    ?? (component as { __name?: string }).__name
+
+  if (!resolved) {
+    throw new Error(
+      'Unable to derive a tool name from the component. Pass `name` to defineTool, '
+      + 'or declare one with defineOptions({ name }): components created with '
+      + '`defineComponent` carry no name unless one is given, while single-file '
+      + 'components are named after their file.',
+    )
+  }
+
+  if (!TOOL_NAME_PATTERN.test(resolved)) {
+    // Reached by this repo's own `*.velin.vue` convention, whose inferred name
+    // keeps the extra dotted segment. Rewriting it silently would change the
+    // name a model is told to call, so say so instead.
+    throw new Error(
+      `"${resolved}" cannot be used as a tool name: providers only accept up to 64 characters `
+      + 'of letters, digits, underscores and hyphens. Pass `name` to defineTool, '
+      + 'or declare one with defineOptions({ name }).',
+    )
+  }
+
+  return resolved
+}
+
+/**
+ * Parses what a provider handed back for a tool call into an arguments object.
+ *
+ * OpenAI-shaped APIs deliver `tool_call.function.arguments` as a JSON *string*,
+ * so accepting one here removes the `JSON.parse` every caller would otherwise
+ * write — including its error handling, which is the part that usually gets
+ * skipped.
+ */
+function parseToolInput(toolName: string, input: unknown): Record<string, unknown> {
+  if (input == null || input === '')
+    return {}
+
+  let value = input
+  if (typeof input === 'string') {
+    try {
+      value = JSON.parse(input)
+    }
+    catch {
+      throw new VelinToolInputError(toolName, ['arguments are not valid JSON'])
+    }
+  }
+
+  // JSON `null` says the same thing as the `null` accepted above.
+  if (value == null)
+    return {}
+
+  if (typeof value !== 'object' || Array.isArray(value))
+    throw new VelinToolInputError(toolName, ['arguments must be a JSON object'])
+
+  return value as Record<string, unknown>
+}
+
+function describeType(value: unknown): string {
+  return Array.isArray(value) ? 'array' : typeof value
+}
+
+function matchesPropType(prop: ComponentProp, value: unknown): boolean {
+  switch (prop.type) {
+    case 'string':
+      return typeof value === 'string'
+    case 'number':
+      return typeof value === 'number' && Number.isFinite(value)
+    case 'boolean':
+      return typeof value === 'boolean'
+    case 'array':
+      return Array.isArray(value)
+    default:
+      // Nothing was derivable about the prop's type, so nothing can be checked.
+      return true
+  }
+}
+
+/**
+ * Narrows a tool call's arguments to the props the component actually declares.
+ *
+ * NOTICE:
+ * Dropping undeclared keys is a safety property, not tidiness. Vue funnels
+ * undeclared root props into fallthrough attributes, and `renderToString`
+ * serializes them before `toMarkdown` runs — so a model that invents an `href`
+ * on a component whose root element is an anchor turns its own tool result into
+ * `[text](https://attacker.example)`, which is then fed back to it. Verified
+ * against this repo's renderer.
+ *
+ * Missing and mistyped values are reported instead of being rendered: a
+ * confidently wrong tool result is worse for a model than an error it can act
+ * on, because it will build on the wrong answer.
+ */
+function pickDeclaredProps(toolName: string, props: ComponentProp[], args: Record<string, unknown>): Record<string, unknown> {
+  const picked: Record<string, unknown> = {}
+  const issues: string[] = []
+
+  for (const prop of props) {
+    // Own properties only: a prop named after an `Object.prototype` member
+    // (`toString`, `constructor`) would otherwise pick up the inherited value
+    // and render it, or fail a type check the model cannot possibly satisfy.
+    const value = Object.hasOwn(args, prop.key) ? args[prop.key] : undefined
+
+    if (value == null) {
+      if (prop.required)
+        issues.push(`missing required argument "${prop.key}"`)
+      // Otherwise leave the key out entirely so the prop's own default applies.
+      continue
+    }
+
+    if (!matchesPropType(prop, value)) {
+      issues.push(`argument "${prop.key}" should be ${prop.type}, received ${describeType(value)}`)
+      continue
+    }
+
+    picked[prop.key] = value
+  }
+
+  if (issues.length > 0)
+    throw new VelinToolInputError(toolName, issues)
+
+  return picked
+}
+
+/**
+ * Turns a prompt component into a tool an LLM can call: its props become the
+ * argument schema, and rendering it with the model's arguments produces the
+ * result.
+ *
+ * Because rendering goes through Vue's server renderer, a component may load
+ * what it needs in `onServerPrefetch` (or an async `setup`) and the rendered
+ * markdown will already include it.
+ *
+ * @example
+ * ```ts
+ * import GetWeather from './GetWeather.vue'
+ *
+ * const tool = defineTool(GetWeather, { description: 'Get the weather for a city.' })
+ *
+ * // tool.function.parameters -> { type: 'object', properties: { city: { type: 'string' } }, ... }
+ * const result = await tool.execute('{"city":"Tokyo"}')
+ * ```
+ */
+export function defineTool<
+  RawProps = any,
+  ComponentProps = ComponentPropsOptions<RawProps>,
+  ResolvedProps = ResolveRenderComponentInputProps<RawProps, ComponentProps>,
+>(
+  component: RenderComponentInputComponent<ResolvedProps>,
+  options?: DefineToolOptions,
+): VelinTool {
+  // The generics exist to keep call sites inferring like `renderComponent` and
+  // `usePrompt`; nothing below is prop-shape specific, so widen once here
+  // rather than threading the parameter through every helper.
+  const target = component as RenderComponentInputComponent<any>
+
+  const props = resolveProps(target)
+  const name = resolveToolName(target, options?.name)
+
+  const fn: VelinTool['function'] = {
+    name,
+    parameters: propsToJsonSchema(props),
+  }
+  if (options?.description)
+    fn.description = options.description
+
+  return {
+    type: 'function',
+    function: fn,
+    execute: async (input, executeOptions) => {
+      const args = pickDeclaredProps(name, props, parseToolInput(name, input))
+
+      // Fail before rendering rather than after: a component's own fetch may
+      // ignore the signal, and there is nothing to return once it has run.
+      executeOptions?.abortSignal?.throwIfAborted()
+
+      const app = onlyRender(target, args)
+      // Provided rather than passed as a prop so it never reaches the template
+      // or collides with a declared prop name.
+      app.provide(velinToolContextKey, executeOptions ?? {})
+
+      return toMarkdown(await renderToString(app))
+    },
+  }
+}

--- a/packages/vue/src/composables/index.ts
+++ b/packages/vue/src/composables/index.ts
@@ -1,1 +1,2 @@
 export * from './usePrompt'
+export * from './useTool'

--- a/packages/vue/src/composables/useTool/index.test.ts
+++ b/packages/vue/src/composables/useTool/index.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import { defineComponent, h, onServerPrefetch, ref } from 'vue'
+
+import { useTool } from './'
+
+const GetWeather = defineComponent({
+  name: 'get_weather',
+  props: { city: { type: String, required: true } },
+  setup: props => () => h('div', `Weather for ${props.city}`),
+})
+
+describe('useTool', () => {
+  it('should expose the derived tool descriptor', () => {
+    const tool = useTool(GetWeather, { description: 'Get the weather.' })
+
+    expect(tool.type).toBe('function')
+    expect(tool.function.name).toBe('get_weather')
+    expect(tool.function.description).toBe('Get the weather.')
+    expect(tool.function.parameters).toEqual({
+      type: 'object',
+      properties: { city: { type: 'string' } },
+      required: ['city'],
+      additionalProperties: false,
+    })
+  })
+
+  it('should render the component when called', async () => {
+    const tool = useTool(GetWeather)
+    await expect(tool.execute({ city: 'Tokyo' })).resolves.toBe('Weather for Tokyo\n')
+  })
+
+  it('should report pending while a call is in flight', async () => {
+    const Slow = defineComponent({
+      name: 'slow_tool',
+      setup() {
+        const done = ref(false)
+        onServerPrefetch(async () => {
+          await new Promise(resolve => setTimeout(resolve, 5))
+          done.value = true
+        })
+        return () => h('div', `done ${done.value}`)
+      },
+    })
+
+    const tool = useTool(Slow)
+    expect(tool.pending.value).toBe(false)
+
+    const call = tool.execute()
+    expect(tool.pending.value).toBe(true)
+
+    await call
+    expect(tool.pending.value).toBe(false)
+  })
+
+  // Runners execute a turn's tool calls with `Promise.all`, and a model may
+  // call the same tool more than once, so both calls share this tool object.
+  it('should stay pending until the last concurrent call settles', async () => {
+    const Delayed = defineComponent({
+      name: 'delayed_tool',
+      props: { ms: { type: Number, required: true } },
+      setup(props) {
+        const done = ref(false)
+        onServerPrefetch(async () => {
+          await new Promise(resolve => setTimeout(resolve, props.ms))
+          done.value = true
+        })
+        return () => h('div', `done ${done.value}`)
+      },
+    })
+
+    const tool = useTool(Delayed)
+    const short = tool.execute({ ms: 1 })
+    const long = tool.execute({ ms: 40 })
+
+    await short
+    expect(tool.pending.value).toBe(true)
+
+    await long
+    expect(tool.pending.value).toBe(false)
+  })
+
+  it('should clear pending when a call fails', async () => {
+    const tool = useTool(GetWeather)
+
+    await expect(tool.execute({})).rejects.toThrow()
+    expect(tool.pending.value).toBe(false)
+  })
+
+  // `pending` is a Ref: it must never travel to a provider alongside the
+  // tool's name and parameters.
+  it('should keep pending out of the serialized tool', () => {
+    const tool = useTool(GetWeather)
+
+    expect(Object.keys(tool)).not.toContain('pending')
+    expect(JSON.parse(JSON.stringify(tool))).toEqual({
+      type: 'function',
+      function: {
+        name: 'get_weather',
+        parameters: {
+          type: 'object',
+          properties: { city: { type: 'string' } },
+          required: ['city'],
+          additionalProperties: false,
+        },
+      },
+    })
+  })
+})

--- a/packages/vue/src/composables/useTool/index.ts
+++ b/packages/vue/src/composables/useTool/index.ts
@@ -1,0 +1,70 @@
+import type {
+  DefineToolOptions,
+  RenderComponentInputComponent,
+  ResolveRenderComponentInputProps,
+  VelinTool,
+} from '@velin-dev/core-vue'
+import type { ComponentPropsOptions, Ref } from 'vue'
+
+import { defineTool } from '@velin-dev/core-vue'
+import { ref } from 'vue'
+
+export type UseToolReturn = VelinTool & {
+  /**
+   * Whether any call is currently rendering. Mirrors `usePrompt`'s `rendering`,
+   * but stays true until the last concurrent call settles — a model may call
+   * the same tool several times in one turn, and runners execute those in
+   * parallel.
+   */
+  readonly pending: Ref<boolean>
+}
+
+/**
+ * Exposes a prompt component as an LLM tool, tracking whether a call is in
+ * flight so the UI can react to it.
+ *
+ * The returned value is the tool itself, so it can be handed to an SDK
+ * directly. `pending` is attached non-enumerably: a `Ref` must never end up in
+ * a serialized request body next to `name` and `parameters`.
+ *
+ * @example
+ * ```ts
+ * import GetWeather from './GetWeather.vue'
+ *
+ * const tool = useTool(GetWeather, { description: 'Get the weather for a city.' })
+ * const result = await generateText({ ...options, messages, tools: [tool] })
+ * ```
+ */
+export function useTool<
+  RawProps = any,
+  ComponentProps = ComponentPropsOptions<RawProps>,
+  ResolvedProps = ResolveRenderComponentInputProps<RawProps, ComponentProps>,
+>(
+  component: RenderComponentInputComponent<ResolvedProps>,
+  options?: DefineToolOptions,
+): UseToolReturn {
+  const tool = defineTool(component, options)
+  const pending = ref(false)
+
+  // Counted rather than a plain flag: parallel tool calls share this one tool
+  // object, so the first call to settle must not report the rest as finished.
+  let inFlight = 0
+
+  const execute = tool.execute
+  tool.execute = async (input, executeOptions) => {
+    inFlight += 1
+    pending.value = true
+    try {
+      return await execute(input, executeOptions)
+    }
+    finally {
+      inFlight -= 1
+      if (inFlight === 0)
+        pending.value = false
+    }
+  }
+
+  Object.defineProperty(tool, 'pending', { value: pending, enumerable: false })
+
+  return tool as UseToolReturn
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -69,6 +69,7 @@ export default defineConfig({
             'packages/source-react/src/**/*.{test,spec}.{ts,tsx}',
             'packages/source-vue/src/**/*.{test,spec}.{ts,tsx}',
             'packages/utils/src/**/*.{test,spec}.{ts,tsx}',
+            'packages/vue/src/**/*.{test,spec}.{ts,tsx}',
           ],
           exclude: ['**/*.browser.{test,spec}.{ts,tsx}', '**/node_modules/**'],
         },


### PR DESCRIPTION
Closes #14

A prompt component already holds everything a tool call needs: its props are the arguments, its script does the work, and what it renders is the answer. This adds the piece that was missing — deriving the argument schema from the props — so the same component an app prompts with can be handed to a model.

It follows the shape sketched in the issue thread: `defineProps` → JSON Schema → a tool reference the LLM can use, with `fetch` → `onServerPrefetch` → auto-render. That second half turned out to already work: `renderComponent` builds a `createSSRApp` and calls `renderToString`, so `onServerPrefetch` and async `setup` are awaited today. Only the schema half needed writing.

```html
<!-- GetWeather.vue -->
<script setup lang="ts">
import { onServerPrefetch, ref } from 'vue'

const props = defineProps<{ city: string }>()

const forecast = ref('')
onServerPrefetch(async () => {
  forecast.value = await fetch(`https://example.com/weather/${props.city}`).then(r => r.text())
})
</script>

<template>
  <div>The weather in {{ city }} is {{ forecast }}.</div>
</template>
```

```ts
import { defineTool } from '@velin-dev/core-vue'

import GetWeather from './GetWeather.vue'

const tool = defineTool(GetWeather, { description: 'Get the current weather for a city.' })

tool.function.parameters
// { type: 'object', properties: { city: { type: 'string' } }, required: ['city'], additionalProperties: false }

await generateText({ ...options, messages, tools: [tool] })   // runner calls execute() itself
const result = await tool.execute(call.function.arguments)     // or drive it yourself
```

`useTool` in `@velin-dev/vue` returns the same tool plus a `pending` ref, mirroring `usePrompt`'s `rendering`.

## What's in it

- **`propsToJsonSchema`** (`core-vue/render-shared/json-schema.ts`) — maps the existing `resolveProps` output onto an object schema. `required` is omitted rather than emitted empty (draft-04 forbids `[]` and some provider validators enforce it), `title` is left out because `resolveProps` sets it equal to the key, and `additionalProperties` is always `false`.
- **`defineTool`** (`core-vue/render-shared/tool.ts`) — the descriptor plus `execute`, argument parsing/validation, and `useToolContext` for reaching the call's `abortSignal` from inside `onServerPrefetch`.
- **`useTool`** (`vue/composables/useTool`) — `defineTool` plus the `pending` ref, attached non-enumerably so a `Ref` can never end up in a serialized request body.

## Decisions worth reviewing

**The descriptor's enumerable fields are exactly the OpenAI wire tool.** `JSON.stringify(tool)` yields `{type, function: {name, description, parameters}}` — `execute` is a function and drops out on its own — while runners that execute tools themselves call `execute` directly. No adapter either way.

**`execute` is `(input?: unknown, options?: VelinToolExecuteOptions) => Promise<string>`, and the wide parameters are load-bearing.** Function parameters are contravariant, so narrowing the first to `Record<string, unknown>` — or requiring fields on the second — makes the descriptor unassignable to a runner's tool type, and the error surfaces in the *user's* project rather than here. `tool.test.ts` pins this with a compile-time assertion against a transcription of `@xsai/shared-chat`'s `Tool`; I kept it a local transcription rather than a devDependency so this package stays SDK-agnostic. Reverting the signature fails `pnpm typecheck`.

Relatedly, `JsonSchema` is declared as a `type` alias, not an `interface`: only type aliases get an implicit index signature, and without one the schema is not assignable to the `Record<string, unknown>` those SDKs declare for `parameters`. There's a comment on the declaration, because switching it to an interface compiles here and breaks at the call site.

**Arguments are narrowed to declared props, and that's a safety property rather than tidiness.** Vue funnels undeclared root props into fallthrough attributes, which `renderToString` serializes before `toMarkdown` runs. On a component whose root is an anchor, a model-invented `href` came back as `[Weather for Tokyo](https://attacker.example/steal)` — inside the tool result then fed to that same model. Verified against this repo's renderer; there's a test for it.

**`execute` throws on bad input instead of rendering something.** A confidently wrong tool result is worse for a model than an error, because it builds on it. `VelinToolInputError` lists every problem at once so one message can correct the model, and its text is written to be handed straight back.

**Also fixed: array-form prop declarations.** `defineProps(['city'])` survives compilation as `props: ['city']`, and `resolveProps` enumerated it as an object — yielding `{key: '0'}`. That was inert before (only `normalizeProps` consumed it, gated on `required`), but it would have advertised a tool argument literally named `"0"` and rendered `undefined`. `resolveProps` now handles the array form; `props.test.ts` covers both entry paths.

## Two things I'd like your call on

1. **Placement.** The schema mapper sits in `core-vue/render-shared` next to `props.ts`, since it consumes `ComponentProp`. If you'd rather it live in `@velin-dev/utils` as a framework-agnostic transform so `core-react` can share it later, that's a file move with no public API change — say the word.
2. **`vitest.config.ts`.** `packages/vue` wasn't in any vitest project, so tests placed there were silently never run. I added it to `packages-node` to cover `useTool`. Happy to split that out if you'd rather it not ride along.

## Not in this PR

Deliberately deferred, all additive later: the OpenAI structured-outputs `strict` transform, Standard Schema, React parity, per-prop schema overrides for type-only `defineProps<T>()`, and argument coercion.

One inherited limitation worth naming: a prop named after an `Object.prototype` member (`toString`) can't be delivered by Vue through `props.toString` at all. Velin's side is fixed — such an argument is no longer misread as "supplied" — but the prop itself remains unusable.

## Tested

```sh
pnpm test:run     # node projects: 129 passed (was 84)
pnpm lint
pnpm typecheck
pnpm build:packages
```

Covers schema derivation per prop type, the envelope rules, the `execute` round trip including `onServerPrefetch`, JSON-string arguments, argument validation and filtering, name resolution, and `pending` across concurrent calls. Each fix was reverse-verified — reverting it turns the corresponding test red.

Note the four `*.browser.test.ts` files fail to load on my machine before and after this branch (a local vite/playwright issue), so I verified against the node projects.
