### PR TITLE
test: run Vitest browser projects headlessly

### DIFF
--- a/packages/core-react/vitest.config.ts
+++ b/packages/core-react/vitest.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
           exclude: ['**/node_modules/**'],
           browser: {
             enabled: true,
+            headless: true,
             provider: playwright(),
             instances: [
               { browser: 'chromium' },

--- a/packages/core-vue/vitest.config.ts
+++ b/packages/core-vue/vitest.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
           exclude: ['**/node_modules/**'],
           browser: {
             enabled: true,
+            headless: true,
             provider: playwright(),
             instances: [
               { browser: 'chromium' },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
           exclude: ['**/node_modules/**'],
           browser: {
             enabled: true,
+            headless: true,
             provider: playwright(),
             instances: [
               { browser: 'chromium' },
@@ -52,6 +53,7 @@ export default defineConfig({
           exclude: ['**/node_modules/**'],
           browser: {
             enabled: true,
+            headless: true,
             provider: playwright(),
             instances: [
               { browser: 'chromium' },
@@ -83,6 +85,7 @@ export default defineConfig({
           exclude: ['**/node_modules/**'],
           browser: {
             enabled: true,
+            headless: true,
             provider: playwright(),
             instances: [
               { browser: 'chromium' },


### PR DESCRIPTION
## Summary

Run every Vitest Browser project in headless mode. The tests still use Playwright Chromium, but local runs no longer open visible browser windows.

## Verification

Passed:

- `pnpm exec vitest run --project core-vue-browser --project core-react-browser --project playground-browser`
- `pnpm exec vitest run --config packages/core-vue/vitest.config.ts --project browser`
- `pnpm exec vitest run --config packages/core-react/vitest.config.ts --project browser`
- `pnpm lint`

Existing failures on `main`:

- `pnpm test:run` fails six Node tests because `defineTool` is not a function.
- `pnpm typecheck` reports missing `@velin-dev/core-vue` exports used by `packages/vue`.

This PR changes only Vitest Browser configuration.